### PR TITLE
Add CI using Gambit builds from main repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: gambit/hello - CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  Windows-msvc:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: daviwil/download-gambit@v1
+      with:
+        artifact-token: ${{ secrets.ARTIFACT_TOKEN }}
+
+    - name: Run Tests
+      run: gsi test.scm
+
+  Windows-mingw:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: daviwil/download-gambit@v1
+      with:
+        os: win-mingw
+        artifact-token: ${{ secrets.ARTIFACT_TOKEN }}
+
+    - name: Run Tests
+      run: gsi test.scm
+
+  Linux:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: daviwil/download-gambit@v1
+      with:
+        artifact-token: ${{ secrets.ARTIFACT_TOKEN }}
+
+    - name: Run Tests
+      run: gsi test.scm
+
+  MacOS:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: daviwil/download-gambit@v1
+      with:
+        artifact-token: ${{ secrets.ARTIFACT_TOKEN }}
+
+    - name: Run Tests
+      run: gsi test.scm

--- a/test.scm
+++ b/test.scm
@@ -1,20 +1,20 @@
 (define-library (github.com/gambit/hello test)
 
   (import (..))     ;; relative import of hello (preserves the version)
-  (import (_test))  ;; for check-equal? and check-tail-exn
+  (import (_test))  ;; for test-equal? and test-error-tail
   (import (gambit)) ;; for lambda, with-output-to-string, and
                     ;; wrong-number-of-arguments-exception?
 
   (begin
 
-    (check-equal? (with-output-to-string (lambda () (hi "you")))
-                  "hello you!\n")
+    (test-equal? "hello you!\n"
+                 (with-output-to-string (lambda () (hi "you"))))
 
-    (check-equal? (with-output-to-string (lambda () (salut "hi")))
-                  "bonjour hi!\n")
+    (test-equal? "bonjour hi!\n"
+                 (with-output-to-string (lambda () (salut "hi"))))
 
-    (check-tail-exn wrong-number-of-arguments-exception?
-                    (lambda () (hi)))
+    (test-error-tail wrong-number-of-arguments-exception?
+                     (lambda () (hi)))
 
-    (check-tail-exn wrong-number-of-arguments-exception?
-                    (lambda () (hi "foo" "bar")))))
+    (test-error-tail wrong-number-of-arguments-exception?
+                     (lambda () (hi "foo" "bar")))))

--- a/test.scm
+++ b/test.scm
@@ -14,7 +14,7 @@
                 (with-output-to-string (lambda () (salut "hi"))))
 
     (test-error-tail wrong-number-of-arguments-exception?
-                     (lambda () (hi)))
+                     ((lambda () (hi))))
 
     (test-error-tail wrong-number-of-arguments-exception?
-                     (lambda () (hi "foo" "bar")))))
+                     ((lambda () (hi "foo" "bar"))))))

--- a/test.scm
+++ b/test.scm
@@ -1,17 +1,17 @@
 (define-library (github.com/gambit/hello test)
 
   (import (..))     ;; relative import of hello (preserves the version)
-  (import (_test))  ;; for test-equal? and test-error-tail
+  (import (_test))  ;; for test-equal and test-error-tail
   (import (gambit)) ;; for lambda, with-output-to-string, and
                     ;; wrong-number-of-arguments-exception?
 
   (begin
 
-    (test-equal? "hello you!\n"
-                 (with-output-to-string (lambda () (hi "you"))))
+    (test-equal "hello you!\n"
+                (with-output-to-string (lambda () (hi "you"))))
 
-    (test-equal? "bonjour hi!\n"
-                 (with-output-to-string (lambda () (salut "hi"))))
+    (test-equal "bonjour hi!\n"
+                (with-output-to-string (lambda () (salut "hi"))))
 
     (test-error-tail wrong-number-of-arguments-exception?
                      (lambda () (hi)))


### PR DESCRIPTION
Hey @feeley, here's a demo of a CI workflow downloading the most recent Gambit build from CI on `master` of the Gambit repo using the new custom GitHub Action [daviwil/download-gambit](https://github.com/daviwil/download-gambit).  Once the Gambit build is downloaded, I can run the tests in `test.scm` successfully.  I think this is a good example for how CI on all Gambit module repos could work!

You can see the output of a test run here: https://github.com/daviwil/hello/runs/717382764?check_suite_focus=true

Ultimately I'd like to move `daviwil/download-gambit` into the Gambit org at some point, but that doesn't have to happen yet for it to be useful.

/cc @lassik